### PR TITLE
feat: Swap consecutive student seat IDs in Seat table

### DIFF
--- a/MySql/top-sql-50/exchange-seats.sql
+++ b/MySql/top-sql-50/exchange-seats.sql
@@ -1,0 +1,55 @@
+Table: Seat
+
++-------------+---------+
+| Column Name | Type    |
++-------------+---------+
+| id          | int     |
+| student     | varchar |
++-------------+---------+
+id is the primary key (unique value) column for this table.
+Each row of this table indicates the name and the ID of a student.
+The ID sequence always starts from 1 and increments continuously.
+ 
+
+Write a solution to swap the seat id of every two consecutive students. If the number of students is odd, the id of the last student is not swapped.
+
+Return the result table ordered by id in ascending order.
+
+The result format is in the following example.
+
+ 
+
+Example 1:
+
+Input: 
+Seat table:
++----+---------+
+| id | student |
++----+---------+
+| 1  | Abbot   |
+| 2  | Doris   |
+| 3  | Emerson |
+| 4  | Green   |
+| 5  | Jeames  |
++----+---------+
+Output: 
++----+---------+
+| id | student |
++----+---------+
+| 1  | Doris   |
+| 2  | Abbot   |
+| 3  | Green   |
+| 4  | Emerson |
+| 5  | Jeames  |
++----+---------+
+Explanation: 
+Note that if the number of students is odd, there is no need to change the last one's seat.
+
+# Time:  O(nlogn)
+# Space: O(n)
+
+# Answer
+
+SELECT s1.id, COALESCE(s2.student, s1.student) AS student
+FROM seat s1 LEFT JOIN seat s2 ON ((s1.id + 1) ^ 1) - 1 = s2.id
+ORDER BY s1.id;


### PR DESCRIPTION
- Added SQL query to swap IDs of every two consecutive students.
- Handles odd number of students by leaving the last student's ID unchanged.
- Utilizes COALESCE and bitwise XOR for swapping.
- Returns results ordered by ID in ascending order.

Time Complexity: O(n log n)
Space Complexity: O(n)